### PR TITLE
Tiny optimization of the 'print_heximal_entry' macro.

### DIFF
--- a/include/hex_numbers.inc
+++ b/include/hex_numbers.inc
@@ -88,11 +88,7 @@
 %endmacro
 
 %macro print_heximal_entry 0
-			pushad
-			pushfd
 			putchar 0x30
 			putchar 0x78
-			popfd
-			popad
 %endmacro
 


### PR DESCRIPTION
Not necessary because of the putchar realization specifics.