### PR TITLE
Critical bug

### DIFF
--- a/include/hex_numbers.inc
+++ b/include/hex_numbers.inc
@@ -46,22 +46,14 @@
 				mov ebx, 1
 				mov edx, 1
 				lea ecx, [ecx + %1]
-				pushad
-				pushfd
 				int 0x80
-				popfd
-				popad
 				pop ecx
 				loop %%again
 				mov eax, 4
 				mov ebx, 1
 				mov edx, 1
 				lea ecx, [%1]
-				pushad
-				pushfd
 				int 0x80
-				popfd
-				popad
 				popfd
 				popad
 %endmacro

--- a/include/hex_numbers.inc
+++ b/include/hex_numbers.inc
@@ -77,11 +77,7 @@
 		mov ebx, 1
 		mov ecx, edi
 		mov edx, 1
-		pushad
-		pushfd
 		int 0x80
-		popfd
-		popad
 		add esp, 2
 		popfd
 		popad


### PR DESCRIPTION
Why do you push registers while all the syscall params are passed through 'em?